### PR TITLE
Automerge type set to "branch" to reduce noise.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
             ],
             "stabilityDays": 1,
             "automerge": true,
+            "automergeType": "branch",
             "matchCurrentVersion": "!/^0/",
             "ignoreTests": true
         },
@@ -31,6 +32,7 @@
             ],
             "stabilityDays": 7,
             "automerge": true,
+            "automergeType": "branch",
             "matchCurrentVersion": "!/^0/"
         },
         {


### PR DESCRIPTION
Following suggestions here:
https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging